### PR TITLE
JMRI fast clock implementation

### DIFF
--- a/esu-bridge.py
+++ b/esu-bridge.py
@@ -348,7 +348,7 @@ while 1:
             
             if operatingMode == "JMRI" and useJMRIClock == True:
                print "Instantiating JMRI websocket interface for clock retrieval on port %d" % webPort
-               timeSource = withrottle.JMRIClock()
+               timeSource = withrottle.JMRIClock(timeZoneOffset)
                try:
                   timeSource.connect(foundIP, webPort)
                except ValueError:
@@ -430,10 +430,7 @@ while 1:
             statusPacket = [ ord('v'), 0x80, gitver[2], gitver[1], gitver[0], 1, 0 ] + getInterfaceTypeByteArray(bridgeTypeStr)
             mrbee.sendpkt(0xFF, statusPacket)
             if operatingMode == "JMRI" and useJMRIClock == True: 
-               try:
-                  hrs = timeSource.getHours() + timeZoneOffset
-               except:
-                  hrs = timeSource.getHours()
+               hrs = timeSource.getHours()
                min = timeSource.getMinutes()
 #               print "JMRI timeSource reports hrs=%d, min=%d" % (hrs, min)
                timePacket = [ ord('T'), 0, 0, 0, 1, hrs, min, 0, 0, 0, 0 ,0 ,0 ]

--- a/protothrottle.ini
+++ b/protothrottle.ini
@@ -5,13 +5,7 @@
 #  withrottle  = JMRI Wifi Throttle (Engine Driver) server
 #  lnwi        = Digitrax LNWI interface
 #  Defaults to "esu" if not specified
-#
-# Uncomment (remove the #) from only one of the following mode lines
-#  and make sure all others start with # (commented out)
-
-mode = esu
-#mode = withrottle
-#mode = lnwi
+mode = withrottle
 
 # baseAddress is a number between 0-31 that sets the base address 
 baseAddress = 0
@@ -24,9 +18,20 @@ packetTimeout = 4000
 
 # serverIP specifies which IP the bridge will connect to
 #  Leave commented out for automatic search and find
-#serverIP = 192.168.7.191
+#serverIP = 192.1.1.1
 
 # serverPort specifies which port the server is listening on
 #  Leave commented out for the default 15471 on ESU or 12090 on WiThrottle
 #serverPort = 12090
+
+# UseJMRIClock is True or False depending on whether one wants to enable the fast
+# clock display of JMRI maintained clock values on the protothrottle display.
+useJMRIClock = 1
+# webPort specifies the port used by JMRI web server.  This used to retrieve
+# the fastclock if enabled above with useJMRIClock = True
+webPort = 12080
+
+# timeZoneOffset is the hours from UTC to set local time on the fast clock show on the display
+# JMRI sends time in UTC only.
+timeZoneOffset = -4
 

--- a/withrottle.py
+++ b/withrottle.py
@@ -330,11 +330,12 @@ class WiThrottleConnection:
       else:
          self.rxtx(None)
 
-class JMRIClock:
+class JMRIClock():
    """class provides for JMRI clock retrieval via websocket interface for transmission to the protothrottle"""
-   def __init__(self):
+   def __init__(self, timeZoneOffset):
       """Constructor for the object.  Any internal initialization should occur here."""
       self.timetext = ""
+      self.offset = int(timeZoneOffset)
 
    def monitorTime(self, threadname, websocket):
         for event in websocket.connect(ping_rate=7):
@@ -360,13 +361,12 @@ class JMRIClock:
    def disconnect(self):
       self.jmriwebsocket.close()
 
-   def getHours(self):
-      
+   def getHours(self):      
       index = self.timetext.find("T")
       if index == -1:
          return 99
       else:
-         return int(self.timetext[index+1:index+3])
+         return int((int(self.timetext[index+1:index+3]) + self.offset) % 24)
 
    def getMinutes(self):
       index = self.timetext.find("T")


### PR DESCRIPTION
This is an attempt at adding fast clock support for JMRI servers.  There is a class JMRIClock in withrottle.py that connects to the JMRI webserver using a websocket (port 12080) to retrieve the fast clock string.  As far as I know this is always in UTC so I've added a simple +- offset from UTC to display "local" time as desired.  I did not want to get into timezone setting and stuff at this point.
protothrottle.ini has 3 new entries for the webPort, a flag useJMRIClock to set if you want to use this functionality and the clock offset parameter.  If the web server is not running a time of 99+offset:99 will be displayed on the protothrottle indicating that you have not received any time updates from JMRI.  If it connects it takes about 30sec to get the first time update.  The time packet is sent to the mrbee in the same area as the status packet is sent in esu-bridge.py.

One point is that I used the lomond websocket client package which would have to be pip installed prior to use in your normal image.  This is a BSD-3 license package and I've included the copyright and disclaimer in withrottle.py.

Also included are 2 updates for connect and disconnect of the withrottle connection.  The connect code was changed to modify the timeout initially since it seems that the connect takes a bit of time (much more than the 0.01 interval used for the normal i/o).  It is then set to 0.01 after the connection.  this seems to connect always on the first try now.
The second update to disconnect is a bunch of try statements to let it stumble through in the case that the JMRI server is rudely disconnected (like shutting down JMRI).  This allows the re-connect loop to start and continue forever until it connects again without bombing out.

Enjoy.